### PR TITLE
Use sha1 to validate checksum

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,27 +1,27 @@
 # packer-templates
-A packer template that simplifies the creation of minimally sized windows vagrant boxes.
+A Packer template that simplifies the creation of minimally-sized Windows Vagrant boxes.
 
-This repo and much of its cotent is covered in detail from [this blog post](http://www.hurryupandwait.io/blog/creating-windows-base-images-for-virtualbox-and-hyper-v-using-packer-boxstarter-and-vagrant). Also see [this post](http://www.hurryupandwait.io/blog/a-packer-template-for-windows-nano-server-weighing-300mb) specifically for the nano template.
+This repo and much of its content are covered in detail from [this blog post](http://www.hurryupandwait.io/blog/creating-windows-base-images-for-virtualbox-and-hyper-v-using-packer-boxstarter-and-vagrant). Also see [this post](http://www.hurryupandwait.io/blog/a-packer-template-for-windows-nano-server-weighing-300mb) specifically for the Nano Server template.
 
 ## Prerequisites
 
-In order to run the template, you will need the following:
+You need the following to run the template:
 
 1. [Packer](https://packer.io/docs/installation.html) installed with a minimum version of 0.8.6.
-2. [Virtualbox](https://www.virtualbox.org/wiki/Downloads)
+2. [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 
 ## Invoking the template
-You may invoke packer to run the template with:
+Invoke `packer` to run the template like this:
 ```
 packer build -force -only virtualbox-iso .\vbox-2012r2.json
 ```
 
 ## Converting to Hyper-V
-This repo includes powershell scripts that can create a Hyper-V vagrant box from the output virtualbox .vmdk file. This repo leverages [psake](https://github.com/psake/psake) and [chocolatey](https://chocolatey.org) to ensure that all prerequisites are installed and then runs the above packer command followed by the scripts needed to produce a vagrant .box file that can create a Hyper-V file.
+This repo includes PowerShell scripts that can create a Hyper-V Vagrant box from the output VirtualBox .vmdk file. This repo leverages [psake](https://github.com/psake/psake) and [Chocolatey](https://chocolatey.org) to ensure that all prerequisites are installed and then runs the above `packer` command followed by the scripts needed to produce a Vagrant .box file that can create a Hyper-V file.
 
-See [this blog post](http://www.hurryupandwait.io/blog/creating-a-hyper-v-vagrant-box-from-a-virtualbox-vmdk-or-vdi-image) for more detail on converting virtualbox disks to Hyper-V.
+See [this blog post](http://www.hurryupandwait.io/blog/creating-a-hyper-v-vagrant-box-from-a-virtualbox-vmdk-or-vdi-image) for more detail on converting VirtualBox disks to Hyper-V.
 
 ## Troubleshooting Boxstarter package run
-[Boxstarter](http://boxstarter.org) is used as the means of provisioning except on nano. Due to the fact that provisioning takes place in the builder and not a provisioner, it can be difficult to gain visibility into why things go wrong from the same console where packer is invoked.
+[Boxstarter](http://boxstarter.org) is used as the means of provisioning except on Nano Server. Due to the fact that provisioning takes place in the builder and not a provisioner, it can be difficult to gain visibility into why things go wrong from the same console where `packer` is run.
 
 Boxstarter will log all package activity output to `$env:LocalAppData\Boxstarter\boxstarter.log` on the guest.

--- a/vbox-2012r2.json
+++ b/vbox-2012r2.json
@@ -9,10 +9,10 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "2" ]
       ],
       "guest_os_type": "Windows2012_64",
-      "headless": "{{ user `headless` }}",    
+      "headless": "{{ user `headless` }}",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "md5",
+      "iso_checksum_type": "sha1",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -37,10 +37,10 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "2" ]
       ],
       "guest_os_type": "Windows2012_64",
-      "headless": "{{ user `headless` }}",    
+      "headless": "{{ user `headless` }}",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "md5",
+      "iso_checksum_type": "sha1",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -76,8 +76,8 @@
   ],
   "variables": {
     "core": "",
-    "headless": "false",    
-    "iso_checksum": "5b5e08c490ad16b59b1d9fab0def883a",
+    "headless": "false",
+    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO"
   }
 }


### PR DESCRIPTION
I haven't diagnosed why, but using MD5 fails from both Ubuntu and Windows hosts (building locally). Changing the checksum to use SHA1 made it work.

I didn't change or experiment with the Nano Server configuration.

I also made some editorial changes to the README.