### PR TITLE
Win7 fixes and enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-iso
-output-virtualbox-iso
+.vagrant/
+iso/
+output-virtualbox-iso/
+*.box
 *.iso
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,19 @@
+Vagrant.configure(2) do |config|
+
+  # Change to the name of your vagrant box
+  config.vm.box = "windows7-ent"
+
+  # This is important as the first boot takes a LONG time.
+  config.vm.boot_timeout = 900
+
+  # Run a "provisioner just to prove that things are working
+  config.vm.provision "shell", inline: "Write-Host 'Heyyyyy, I did it....'"
+
+  # Show the GUI and use 2GB of RAM
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = true
+    vb.memory = "2048"
+  end
+
+end
+

--- a/answer_files/win7/Autounattend.xml
+++ b/answer_files/win7/Autounattend.xml
@@ -44,12 +44,14 @@
                     </InstallTo>
                     <WillShowUI>OnError</WillShowUI>
                     <InstallToAvailablePartition>false</InstallToAvailablePartition>
+                    <!-- Comment out if using Entperprise -->
                     <InstallFrom>
                         <MetaData wcm:action="add">
                             <Key>/IMAGE/NAME</Key>
                             <Value>Windows 7 ULTIMATE</Value>
                         </MetaData>
                     </InstallFrom>
+                    <!-- End comment here -->
                 </OSImage>
             </ImageInstall>
         </component>

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -10,17 +10,39 @@ Update-ExecutionPolicy -Policy Unrestricted
 if (Test-Command -cmdname 'Uninstall-WindowsFeature') {
     Write-BoxstarterMessage "Removing unused features..."
     Remove-WindowsFeature -Name 'Powershell-ISE'
-    Get-WindowsFeature | 
-    ? { $_.InstallState -eq 'Available' } | 
+    Get-WindowsFeature |
+    ? { $_.InstallState -eq 'Available' } |
     Uninstall-WindowsFeature -Remove
 }
 
-
 Install-WindowsUpdate -AcceptEula
+
+if (($PSVersionTable.PSVersion|Select-Object -ExpandProperty Major) -eq "2") {
+  if (!(Test-Path "C:\Users\vagrant\.rebooted")) {
+    Add-Content "C:\Users\vagrant\.rebooted" "rebooting before PowerShell upgrade"
+    shutdown /r /c "rebooting before PowerShell upgrade" /t 05
+    sleep 10
+  }
+
+  Write-Host 'Upgrading PowerShell to avoid known issues in v1 and v2'
+  choco install -y powershell
+  if(Test-PendingReboot) {
+    shutdown /r /c "rebooting after PowerShell upgrade" /t 05
+    sleep 10
+  }
+} elseif (Test-Path "C:\Users\vagrant\.rebooted") {
+  Remove-Item -Force "C:\Users\vagrant\.rebooted"
+  Write-Host "This is Powershell $PSVersionTable.PSVersion"
+} else {
+  Write-Host "This is Powershell $PSVersionTable.PSVersion"
+}
 
 Write-BoxstarterMessage "Removing page file"
 $pageFileMemoryKey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management"
 Set-ItemProperty -Path $pageFileMemoryKey -Name PagingFiles -Value ""
+
+mkdir C:\Windows\Panther\Unattend
+copy-item a:\postunattend.xml C:\Windows\Panther\Unattend\unattend.xml
 
 if(Test-PendingReboot){ Invoke-Reboot }
 

--- a/scripts/virtualbox.ps1
+++ b/scripts/virtualbox.ps1
@@ -1,0 +1,34 @@
+if (Test-Path 'C:\Users\vagrant\.vbox_version') {
+    Write-Host "Installing Virtualbox Guest Additions" -ForegroundColor green
+
+    # Get current version of Virtualbox
+    $vboxVersion = (Get-Content "C:\Users\vagrant\.vbox_version" | Out-String).Trim()
+    $url = "http://download.virtualbox.org/virtualbox/$($vboxVersion)/VBoxGuestAdditions_$($vboxVersion).iso"
+    $isoPath = "C:\Users\vagrant\VBoxGuestAdditions_$($vboxVersion).iso"
+
+    # Download Guest Additions ISO
+    (New-Object System.Net.WebClient).DownloadFile("$($url)","$($isoPath)")
+
+    # Install Virtual CloneDrive and mount the ISO
+    choco install -y virtualclonedrive
+    $vcdmount = 'C:\Program Files (x86)\Elaborate Bytes\VirtualCloneDrive\VCDMount.exe'
+    Start-Process -FilePath "$($vcdmount)" -ArgumentList "$($isoPath)" -Wait
+
+    # Determine where the ISO got mounted
+    $cdrom = [System.IO.DriveInfo]::GetDrives() | ? {$_.VolumeLabel -like "VBOX*" } | select -ExpandProperty Name
+
+    # Install the Guest Additions
+    Start-Process -FilePath ".\VBoxCertUtil.exe" -ArgumentList "add-trusted-publisher oracle-vbox.cer --root oracle-vbox.cer" -WorkingDirectory "$($cdrom)cert" -Wait
+    Write-Host "Installing VBoxGuestAdditions $($vboxVersion)" -ForegroundColor green
+    Start-Process -FilePath "$($cdrom)VBoxWindowsAdditions.exe" -ArgumentList "/S" -Wait
+
+    # Unmount and delete the ISO
+    Start-Process -FilePath "$($vcdmount)" -ArgumentList "/u" -Wait
+    Remove-Item -Force "$($isoPath)"
+
+    Write-Host "Finished installing Virtualbox Guest Additions" -ForegroundColor green
+} else {
+    Write-Host "Unable to install Virtualbox Guest Additions" -ForegroundColor  red
+    ls C:\Users\vagrant\
+    sleep 30
+}

--- a/vbox-win7-ent.json
+++ b/vbox-win7-ent.json
@@ -1,0 +1,60 @@
+{
+    "builders": [{
+    "type": "virtualbox-iso",
+    "vboxmanage": [
+      [ "modifyvm", "{{.Name}}", "--natpf1", "winrm,tcp,,55985,,5985" ],
+      [ "modifyvm", "{{.Name}}", "--memory", "5120" ],
+      [ "modifyvm", "{{.Name}}", "--vram", "36" ],
+      [ "modifyvm", "{{.Name}}", "--cpus", "2" ]
+    ],
+    "guest_os_type": "Windows7_64",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "communicator": "winrm",
+    "headless": "{{ user `headless` }}",
+    "winrm_username": "vagrant",
+    "winrm_password": "vagrant",
+    "winrm_timeout": "24h",
+    "shutdown_command": "C:/windows/system32/sysprep/sysprep.exe /generalize /oobe /unattend:C:/Windows/Panther/Unattend/unattend.xml /quiet /shutdown",
+    "shutdown_timeout": "15m",
+    "floppy_files": [
+      "answer_files/win7/Autounattend.xml",
+      "answer_files/win7/postunattend.xml",
+      "scripts/boxstarter.ps1",
+      "scripts/package.ps1",
+      "scripts/Test-Command.ps1",
+      "scripts/virtualbox.ps1"
+    ],
+    "guest_additions_mode": "disable",
+    "virtualbox_version_file": "C:/Users/vagrant/.vbox_version"
+  }],
+    "provisioners": [
+      {
+        "type": "windows-restart"
+      },
+      {
+        "type": "powershell",
+        "only": "virtualbox-iso",
+        "scripts": [
+          "scripts/virtualbox.ps1"
+        ],
+        "elevated_user": "vagrant",
+        "elevated_password": "vagrant",
+        "remote_path": "C:/Users/vagrant/virtualbox.ps1"
+      }
+    ],
+    "post-processors": [
+    {
+      "type": "vagrant",
+      "keep_input_artifact": true,
+      "output": "windows7-{{.Provider}}.box",
+      "vagrantfile_template": "vagrantfile-windows.template"
+    }
+  ],
+  "variables": {
+    "headless": "false",
+    "iso_checksum": "2c9774a1f48570e749e6d33c642fe8f6f7898cb0",
+    "iso_url": "iso/en_windows_7_enterprise_with_sp1_x64_dvd_620201.iso"
+  }
+}

--- a/vbox-win7.json
+++ b/vbox-win7.json
@@ -12,7 +12,7 @@
     "iso_checksum": "{{ user `iso_checksum` }}",
     "iso_checksum_type": "sha1",
     "communicator": "winrm",
-    "headless": "{{ user `headless` }}",    
+    "headless": "{{ user `headless` }}",
     "winrm_username": "vagrant",
     "winrm_password": "vagrant",
     "winrm_timeout": "24h",
@@ -23,9 +23,27 @@
       "answer_files/win7/postunattend.xml",
       "scripts/boxstarter.ps1",
       "scripts/package.ps1",
-      "scripts/Test-Command.ps1"
-    ]
+      "scripts/Test-Command.ps1",
+      "scripts/virtualbox.ps1"
+    ],
+    "guest_additions_mode": "disable",
+    "virtualbox_version_file": "C:/Users/vagrant/.vbox_version"
   }],
+    "provisioners": [
+      {
+        "type": "windows-restart"
+      },
+      {
+        "type": "powershell",
+        "only": "virtualbox-iso",
+        "scripts": [
+          "scripts/virtualbox.ps1"
+        ],
+        "elevated_user": "vagrant",
+        "elevated_password": "vagrant",
+        "remote_path": "C:/Users/vagrant/virtualbox.ps1"
+      }
+    ],
     "post-processors": [
     {
       "type": "vagrant",


### PR DESCRIPTION
Fixes building Windows 7, adds support for Windows 7 Enterprise.  I had to add back in a line you removed that copies over the postunattend.xml as nothing was doing that in the win7 template anymore. The powershell upgrade is due to a known bug in PS v2 causing the install script of Virtualbox's guest additions to fail. Virtual CloneDrive was added as part of the tools install since Windows 7 can't mount an ISO. The guest part of the template mentioned below is so that the version of Virtualbox can be determined. 
```json
"guest_additions_mode": "disable",
"virtualbox_version_file": "C:/Users/vagrant/.vbox_version"
```
That part of Packer's process does not happen until after the build is done but before the provisioners... that is also way the tools are installed with a provisioner. Lastly, the reboots in the provisioning phase are to resolve issues that were keeping the tools from installing correctly.

I am happy to adjust this if needed. It has only been tested on Win7 Enterprise. 

Oh, this also fixes #27.