### PR TITLE
Libvirt support for Windows 2012R2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 iso
 output-virtualbox-iso
+output-qemu
 *.iso
+*.box

--- a/answer_files/2012_r2/Autounattend.xml
+++ b/answer_files/2012_r2/Autounattend.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
+	<!-- look for drivers on floppy -->
+	<component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+		<DriverPaths>
+			<PathAndCredentials wcm:keyValue="1" wcm:action="add">
+				<Path>A:\</Path>
+			</PathAndCredentials>
+		</DriverPaths>
+	</component>
+
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <SetupUILanguage>
                 <UILanguage>en-US</UILanguage>

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Build script for Fedora 23:
+# 1. Renamed packer to packer.io to avoid clashes with a different packer
+#    executable
+# 2. Set TMPDIR because otherwise packer creates huge temporary files
+#    in /tmp which in Fedora is tmpfs (backed by RAM and limited in
+#    size)
+
+# Prerequisites:
+# 1. Install packer, create a symlink named packer.io to the packer
+#    executable
+# 2. Install the Windows virtio drivers - dnf install virtio-win
+
+# To use with Vagrant:
+# 1. Install vagrant, vagrant-libvirt packages
+# 2. Install vagrant plugins winrm, winrm-fs, vagrant-winrm-syncedfolders
+
+templ_file=$1
+if [[ -z $templ_file ]] ; then
+    templ_file=qemu-2012r2.json
+fi
+
+TMPDIR=$HOME/tmp packer.io build $templ_file
+

--- a/qemu-2012r2.json
+++ b/qemu-2012r2.json
@@ -1,0 +1,56 @@
+{
+  "builders": [
+    {
+      "type": "qemu",
+      "format": "qcow2",
+      "accelerator": "kvm",
+      "qemuargs": [
+      	[ "-m", "2048" ]
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "communicator": "winrm",
+      "winrm_username": "vagrant",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "8h",
+      "shutdown_command": "a:/PackerShutdown.bat",
+      "shutdown_timeout": "15m",
+      "floppy_files": [
+	"answer_files/2012_r2{{user `core`}}/Autounattend.xml",
+	"scripts/oracle.cer",
+	"scripts/postunattend.xml",
+	"scripts/boxstarter.ps1",
+	"scripts/PackerShutdown.bat",
+	"scripts/package.ps1",
+	"scripts/SetupComplete-2012.cmd",
+	"scripts/Test-Command.ps1",
+	"{{ user `virtio_dir`}}/netkvm.*",
+	"{{ user `virtio_dir`}}/viostor.*"
+      ]
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "powershell",
+      "script": "scripts/provision.ps1"
+    }
+  ],
+  "post-processors": [
+    [{
+      "type": "vagrant",
+      "keep_input_artifact": true,
+      "output": "windows2012r2min-{{.Provider}}.box",
+      "vagrantfile_template": "vagrantfile-windows.template"
+    }
+    ]
+  ],
+  "variables": {
+    "core": "",
+    "headless": "false",
+    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "virtio_dir": "/usr/share/virtio-win/drivers/amd64/Win2012R2"
+  }
+}

--- a/vagrantfile-windows.template
+++ b/vagrantfile-windows.template
@@ -13,4 +13,9 @@ Vagrant.configure(2) do |config|
   config.vm.provider 'hyperv' do |hv|
     hv.ip_address_timeout = 240
   end
+
+  config.vm.provider :libvirt do |domain|
+    domain.memory = 2028
+    domain.cpus = 2
+  end
 end


### PR DESCRIPTION
Hi,

This pull request adds support for creating Windows Vagrant boxes for the Vagrant libvirt provider, using the packer qemu builder. Libvirt/qemu (+kvm) are the "native" virtualization tools on Fedora Linux.

The patch attempts to reuse common code as much as is reasonable - so the Autounattend.xml is modified to include drivers on the virtual floppy. This is required for qemu to support virtio drivers which are not built-in on Windows. The directive is "grab whatever you find on A:\" - I hope it won't break vbox builds where there are no drivers (I wonder whether it's possible to always add those drivers to create a one-image-fits-all build. On Linux that works - the extra drivers just sit there and the kernel loads them on demand).