### PR TITLE
windows: add rdp port forwarding

### DIFF
--- a/vagrantfile-windows.template
+++ b/vagrantfile-windows.template
@@ -4,6 +4,7 @@
 Vagrant.configure(2) do |config|
   config.vm.guest = :windows
   config.vm.communicator = "winrm"
+  config.vm.network :forwarded_port, guest: 3389, host: 3389, id: 'rdp', auto_correct: true
 
   config.vm.provider "virtualbox" do |vb|
     vb.gui = true


### PR DESCRIPTION
Vagrant doesn't automatically add this for some reason. Even
though it could do this automatically.

This enables the `vagrant rdp` command.