### PR TITLE
windows-update.ps1 improve output

### DIFF
--- a/scripts/windows-updates.ps1
+++ b/scripts/windows-updates.ps1
@@ -1,3 +1,90 @@
-$ProgressPreference='SilentlyContinue'
+# Silence progress bars in PowerShell, which can sometimes feed back strange
+# XML data to the Packer output.
+$ProgressPreference = "SilentlyContinue"
 
-Get-WUInstall -WindowsUpdate -AcceptAll -UpdateType Software -IgnoreReboot
+Write-Output "Starting PSWindowsUpdate Installation"
+# Install PSWindowsUpdate for scriptable Windows Updates
+$webDeployURL = "https://gallery.technet.microsoft.com/scriptcenter/2d191bcd-3308-4edd-9de2-88dff796b0bc/file/41459/43/PSWindowsUpdate.zip"
+$filePath = "$($env:TEMP)\PSWindowsUpdate.zip"
+
+(New-Object System.Net.WebClient).DownloadFile($webDeployURL, $filePath)
+
+$shell = New-Object -ComObject Shell.Application
+$zipFile = $shell.NameSpace($filePath)
+$destinationFolder = $shell.NameSpace("C:\Program Files\WindowsPowerShell\Modules")
+
+$copyFlags = 0x00
+$copyFlags += 0x04 # Hide progress dialogs
+$copyFlags += 0x10 # Overwrite existing files
+
+$destinationFolder.CopyHere($zipFile.Items(), $copyFlags)
+# Clean up
+Remove-Item -Force -Path $filePath
+
+Write-Output "Ended PSWindowsUpdate Installation"
+
+Write-Output "Starting Windows Update Installation"
+
+Import-Module PSWindowsUpdate
+
+if (Test-Path C:\Windows\Temp\PSWindowsUpdate.log) {
+    # Save old logs
+    Rename-Item -Path C:\Windows\Temp\PSWindowsUpdate.log -NewName PSWindowsUpdate-$((Get-Date).Ticks).log
+
+    # Uncomment the line below to delete old logs instead
+    #Remove-Item -Path C:\Windows\Temp\PSWindowsUpdate.log
+}
+
+try {
+    $updateCommand = {ipmo PSWindowsUpdate; Get-WUInstall -AcceptAll -IgnoreReboot | Out-File C:\Windows\Temp\PSWindowsUpdate.log}
+    $TaskName = "PackerUpdate"
+
+    $User = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $Scheduler = New-Object -ComObject Schedule.Service
+
+    $Task = $Scheduler.NewTask(0)
+
+    $RegistrationInfo = $Task.RegistrationInfo
+    $RegistrationInfo.Description = $TaskName
+    $RegistrationInfo.Author = $User.Name
+
+    $Settings = $Task.Settings
+    $Settings.Enabled = $True
+    $Settings.StartWhenAvailable = $True
+    $Settings.Hidden = $False
+
+    $Action = $Task.Actions.Create(0)
+    $Action.Path = "powershell"
+    $Action.Arguments = "-Command $updateCommand"
+
+    $Task.Principal.RunLevel = 1
+
+    $Scheduler.Connect()
+    $RootFolder = $Scheduler.GetFolder("\")
+    $RootFolder.RegisterTaskDefinition($TaskName, $Task, 6, "SYSTEM", $Null, 1) | Out-Null
+    $RootFolder.GetTask($TaskName).Run(0) | Out-Null
+
+    Write-Output "The Windows Update log will be displayed below this message. No additional output indicates no updates were needed."
+    do {
+		sleep 1
+		if ((Test-Path C:\Windows\Temp\PSWindowsUpdate.log) -and $script:reader -eq $null) {
+			$script:stream = New-Object System.IO.FileStream -ArgumentList "C:\Windows\Temp\PSWindowsUpdate.log", "Open", "Read", "ReadWrite"
+			$script:reader = New-Object System.IO.StreamReader $stream
+		}
+		if ($script:reader -ne $null) {
+			$line = $Null
+			do {$script:reader.ReadLine()
+				$line = $script:reader.ReadLine()
+				Write-Output $line
+			} while ($line -ne $null)
+		}
+	} while ($Scheduler.GetRunningTasks(0) | Where-Object {$_.Name -eq $TaskName})
+} finally {
+    $RootFolder.DeleteTask($TaskName,0)
+    [System.Runtime.Interopservices.Marshal]::ReleaseComObject($Scheduler) | Out-Null
+	if ($script:reader -ne $null) {
+		$script:reader.Close()
+		$script:stream.Dispose()
+	}
+}
+Write-Output "Ended Windows Update Installation"


### PR DESCRIPTION
Hashicorp has a really good script for installing windows updates. 

https://github.com/hashicorp/best-practices/blob/master/packer/scripts/windows/install_windows_updates.ps1


It shows each windows update that is being installed. 


```
==> virtualbox-iso: Provisioning with shell script: scripts/windows/common/windows-updates.ps1
    virtualbox-iso: Starting PSWindowsUpdate Installation
    virtualbox-iso: Ended PSWindowsUpdate Installation
    virtualbox-iso: Starting Windows Update Installation
    virtualbox-iso: The Windows Update log will be displayed below this message. No additional output indicates no updates were needed.
    virtualbox-iso:
    virtualbox-iso: X Status     KB          Size Title
    virtualbox-iso: - ------     --          ---- -----
    virtualbox-iso: 2 Accepted   KB2938066  11 MB Update for Windows Server 2012 R2 (KB2938066)
    virtualbox-iso: 2 Accepted   KB3005628 145 KB Update for Microsoft .NET Framework 3.5 for x6...
    virtualbox-iso: 2 Accepted   KB3013816   5 MB Update for Windows Server 2012 R2 (KB3013816)
    virtualbox-iso: 2 Accepted   KB2989930 164 KB Update for Windows Server 2012 R2 (KB2989930)
    virtualbox-iso: 2 Accepted   KB3004394   1 MB Update for Windows Server 2012 R2 (KB3004394)
    virtualbox-iso: 2 Accepted   KB2934520  72 MB Microsoft .NET Framework 4.5.2 for Windows 8.1...
    virtualbox-iso: 2 Accepted   KB3031044  31 KB Update for Windows Server 2012 R2 (KB3031044)
    virtualbox-iso: 2 Accepted   KB3016074 913 KB Update for Windows Server 2012 R2 (KB3016074)
    virtualbox-iso: 2 Accepted   KB3020338 597 KB Update for Windows Server 2012 R2 (KB3020338)
    virtualbox-iso: 2 Accepted   KB3006137   6 MB Update for Windows Server 2012 R2 (KB3006137)

```