### PR TITLE
Fix 2012r2 VBox packer build

### DIFF
--- a/scripts/provision.ps1
+++ b/scripts/provision.ps1
@@ -6,7 +6,9 @@ netsh advfirewall firewall set rule group="File and Printer Sharing" new enable=
 
 if(Test-Path "e:/VBoxWindowsAdditions.exe") {
     Write-Host "Installing Guest Additions"
-    certutil -addstore -f "TrustedPublisher" A:\oracle.cer
+    Get-ChildItem E:\cert\ -Filter vbox*.cer | ForEach-Object {
+        E:\cert\VBoxCertUtil.exe add-trusted-publisher $_.FullName --root $_.FullName
+    }
 
     mkdir "C:\Windows\Temp\virtualbox" -ErrorAction SilentlyContinue
     Start-Process -FilePath "e:/VBoxWindowsAdditions.exe" -ArgumentList "/S" -WorkingDirectory "C:\Windows\Temp\virtualbox" -Wait
@@ -63,7 +65,7 @@ finally {
         $Stream.Close()
     }
 }
- 
+
 Del $FilePath
 
 Write-Host "copying auto unattend file"

--- a/vbox-2012r2.json
+++ b/vbox-2012r2.json
@@ -22,6 +22,7 @@
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
       "winrm_timeout": "12h",
+      "winrm_port" : "55985",
       "shutdown_command": "a:/PackerShutdown.bat",
       "shutdown_timeout": "15m",
       "floppy_files": [


### PR DESCRIPTION
* The packer build needs to know to use port 55985 for WinRM since virtualbox is forwarding 127.0.0.1:55895 to the guest VM on port 5985. 

* Guest additions need to be installed as per https://www.virtualbox.org/manual/ch04.html. Certificates need to be installed using VBoxCertUtil before running VBoxWindowsAdditions.exe /S
