### PR TITLE
update default value for guest_additions_mode

### DIFF
--- a/vbox-2012r2-wmf5.json
+++ b/vbox-2012r2-wmf5.json
@@ -104,7 +104,7 @@
   ],
   "variables": {
     "core": "",
-    "guest_additions_mode": "upload",
+    "guest_additions_mode": "attach",
     "headless": "true",
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO"


### PR DESCRIPTION
I've changed the default value for guest_additions_mode from upload to attach. Provision.ps1 looks for the guest additions on the E drive, so if guest_additions_mode is set to upload, it won't be found and installed. I think this should help with https://github.com/test-kitchen/test-kitchen/issues/1171 for people using the wmf5 template.