### PR TITLE
adapt win2k16 methodology for win2k12

### DIFF
--- a/answer_files/2012_r2/Autounattend.xml
+++ b/answer_files/2012_r2/Autounattend.xml
@@ -134,7 +134,7 @@
             </AutoLogon>
       <FirstLogonCommands>
         <SynchronousCommand wcm:action="add">
-           <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\boxstarter.ps1</CommandLine>
+           <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\winrm.ps1</CommandLine>
            <Order>1</Order>
         </SynchronousCommand>
       </FirstLogonCommands>

--- a/scripts/install_wmf.ps1
+++ b/scripts/install_wmf.ps1
@@ -1,0 +1,12 @@
+$source = "http://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+$destination = "c:\windows\temp\KB3134758.msu"
+
+Write-Host "Downloading WMF 5.0 RTM..."
+Invoke-WebRequest -Uri $source -OutFile $destination
+
+Write-Host "Installing WMF 5.0 RTM..."
+if (Test-Path $destination) {
+  Start-Process -FilePath "wusa.exe" -ArgumentList "$destination /quiet /norestart" -Wait
+} else {
+  Write-Error "Cannot find: $destination" -ErrorAction:Stop
+}

--- a/vbox-2012r2.json
+++ b/vbox-2012r2.json
@@ -3,7 +3,6 @@
     {
       "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--natpf1", "guest_winrm,tcp,,55985,,5985" ],
         [ "modifyvm", "{{.Name}}", "--memory", "2048" ],
         [ "modifyvm", "{{.Name}}", "--vram", "48" ],
         [ "modifyvm", "{{.Name}}", "--cpus", "2" ]
@@ -21,26 +20,19 @@
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_port": 55985,
       "winrm_timeout": "12h",
-      "winrm_port" : "55985",
-      "shutdown_command": "a:/PackerShutdown.bat",
+      "winrm_port": 5985,
+      "shutdown_command": "C:/Windows/Panther/Unattend/packer_shutdown.bat",
       "shutdown_timeout": "15m",
       "floppy_files": [
-        "answer_files/2012_r2{{user `core`}}/Autounattend.xml",
-        "scripts/postunattend.xml",
-        "scripts/boxstarter.ps1",
-        "scripts/PackerShutdown.bat",
-        "scripts/package.ps1",
-        "scripts/SetupComplete-2012.cmd",
-        "scripts/Test-Command.ps1"
+        "answer_files/2012_r2/Autounattend.xml",
+        "scripts/winrm.ps1"
       ]
     },
     {
       "name": "virtualbox-iso-atlas",
       "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--natpf1", "guest_winrm,tcp,,55985,,5985" ],
         [ "modifyvm", "{{.Name}}", "--memory", "2048" ],
         [ "modifyvm", "{{.Name}}", "--vram", "36" ],
         [ "modifyvm", "{{.Name}}", "--cpus", "2" ]
@@ -56,25 +48,79 @@
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_port": 55985,
+      "winrm_port": 5985,
       "winrm_timeout": "12h",
-      "shutdown_command": "a:/PackerShutdown.bat",
+      "shutdown_command": "C:/Windows/Panther/Unattend/packer_shutdown.bat",
       "shutdown_timeout": "15m",
       "floppy_files": [
-        "answer_files/2012_r2{{user `core`}}/Autounattend.xml",
-        "scripts/postunattend.xml",
-        "scripts/boxstarter.ps1",
-        "scripts/PackerShutdown.bat",
-        "scripts/package.ps1",
-        "scripts/SetupComplete-2012.cmd",
-        "scripts/Test-Command.ps1"
+        "answer_files/2012_r2/Autounattend.xml",
+        "scripts/winrm.ps1"
       ]
     }
   ],
   "provisioners": [
     {
       "type": "powershell",
-      "script": "scripts/provision.ps1"
+      "script": "scripts/install_wmf.ps1",
+      "elevated_user": "vagrant",
+      "elevated_password": "vagrant"
+    },
+    {
+      "type": "windows-restart",
+      "restart_timeout": "15m"
+    },
+    {      
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks", "vendor/cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "wsus-client::configure",
+        "packer-templates::install_ps_modules",
+        "packer-templates::vbox_guest_additions",
+        "packer-templates::uninstall_powershell_ise",
+        "packer-templates::delete_pagefile"
+      ]
+    },
+    {
+      "type": "powershell",
+      "script": "scripts/windows-updates.ps1",
+      "elevated_user": "vagrant",
+      "elevated_password": "vagrant"
+    },
+    {
+      "type": "windows-restart",
+      "restart_timeout": "15m"
+    },
+    {
+      "type": "powershell",
+      "script": "scripts/after-reboot.ps1",
+      "elevated_user": "vagrant",
+      "elevated_password": "vagrant"
+    },
+    {
+      "type": "chef-solo",
+      "remote_cookbook_paths": [
+        "c:/windows/temp/packer-chef-solo/cookbooks-0",
+        "c:/windows/temp/packer-chef-solo/cookbooks-1"
+      ],
+      "guest_os_type": "windows",
+      "skip_install": "true",
+      "run_list": [
+        "packer-templates::enable_file_sharing",
+        "packer-templates::remote_desktop",
+        "packer-templates::clean_sxs",
+        "packer-templates::add_postunattend",
+        "packer-templates::add_pagefile",
+        "packer-templates::set_local_account_token_filter_policy",
+        "packer-templates::remove_dirs",
+        "packer-templates::add_setup_complete"
+      ]
+    },
+    {
+      "type": "powershell",
+      "script": "scripts/cleanup.ps1",
+      "elevated_user": "vagrant",
+      "elevated_password": "vagrant"
     }
   ],
   "post-processors": [
@@ -96,9 +142,8 @@
     }]
   ],
   "variables": {
-    "core": "",
     "guest_additions_mode": "attach",
-    "headless": "false",
+    "headless": "true",
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO"
   }


### PR DESCRIPTION
Retrofits win2k12r2 template to use same methodology as the win2k16 template. Nothing earth shattering and not certain you'll be interested in this patch, but here it is.
- introduces script for installing WMF 5 in win2k12
- removes custom WinRM port mapping (not required in packer 0.12.2)
- tested with VBox 5.1.14, packer 0.12.2