### PR TITLE
WinRM port change

### DIFF
--- a/vbox-2012r2.json
+++ b/vbox-2012r2.json
@@ -18,7 +18,7 @@
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
       "winrm_timeout": "12h",
-      "winrm_port" : "55985",
+      "winrm_port" : "5985",
       "shutdown_command": "a:/PackerShutdown.bat",
       "shutdown_timeout": "15m",
       "floppy_files": [


### PR DESCRIPTION
I saw this had been fixed on a different template (vbox-2016.json?), but not here. My current install of Win2012R2 got hung up at:
"==> virtualbox-iso: Waiting for WinRM to become available..."
I was able to change the WinRM port on my virtual machine (and change the port in the firewall) to 55985, which did allow the install to proceed. My guess is that this change is necessary to proceed without the 'dirty tweaking' I just performed.