### PR TITLE
Fix Guest OS type for 2016

### DIFF
--- a/vbox-2016.json
+++ b/vbox-2016.json
@@ -8,7 +8,7 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "2" ]
       ],
       "guest_additions_mode": "{{ user `guest_additions_mode` }}",
-      "guest_os_type": "Windows2012_64",
+      "guest_os_type": "Windows2016_64",
       "headless": "{{ user `headless` }}",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",


### PR DESCRIPTION
Just trying this out today, and it is _awesome._

I noticed that the Guest OS type for the 2016 template listed `Windows2012_64` - just updating it to 2016.