### PR TITLE
Corrected cookbook path for Windows Server 2016 .json files

### DIFF
--- a/hyperv-2016.json
+++ b/hyperv-2016.json
@@ -24,7 +24,7 @@
   "provisioners": [
     {
       "type": "chef-solo",
-      "cookbook_paths": ["cookbooks", "vendor/cookbooks"],
+      "cookbook_paths": ["cookbooks", "cookbooks"],
       "guest_os_type": "windows",
       "run_list": [
         "wsus-client::configure",

--- a/vbox-2016.json
+++ b/vbox-2016.json
@@ -28,7 +28,7 @@
   "provisioners": [
     {
       "type": "chef-solo",
-      "cookbook_paths": ["cookbooks", "vendor/cookbooks"],
+      "cookbook_paths": ["cookbooks", "cookbooks"],
       "guest_os_type": "windows",
       "run_list": [
         "wsus-client::configure",


### PR DESCRIPTION
The cookbook path for both the vbox and hyper-v .json files for server 2016 used the path "Vendors\cookbooks" which is incorrect.  Truncated it to just "cookbooks"