### PR TITLE
Correct path to psake.ps1 and psake tools

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -16,4 +16,4 @@ if(!(Get-Command packer -ErrorAction SilentlyContinue)) { cinst packer -y }
 
 $psakeDir = (dir $env:ChocolateyInstall\lib\Psake*)
 if($psakeDir.length -gt 0) {$psakerDir = $psakeDir[-1]}
-."$psakeDir\tools\psake.ps1" "$here/psakeBuild.ps1" $Action -ScriptPath $psakeDir\tools -parameters $PSBoundParameters
+."$psakeDir\tools\psake\psake.ps1" "$here/psakeBuild.ps1" $Action -ScriptPath $psakeDir\tools\psake -parameters $PSBoundParameters


### PR DESCRIPTION
Hi!
There is a problem with path to psake tools in your scripts.
On my Windows 10 system psake tools with all related files was installed on C:\ProgramData\chocolatey\lib\psake\tools\psake
not C:\ProgramData\chocolatey\lib\psake\tools