### PR TITLE
Update Win2012 ISO and increase memory

### DIFF
--- a/vbox-2012r2.json
+++ b/vbox-2012r2.json
@@ -3,7 +3,7 @@
     {
       "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "2048" ],
+        [ "modifyvm", "{{.Name}}", "--memory", "4096" ],
         [ "modifyvm", "{{.Name}}", "--vram", "48" ],
         [ "modifyvm", "{{.Name}}", "--cpus", "2" ]
       ],
@@ -90,7 +90,7 @@
     "core": "",
     "guest_additions_mode": "attach",
     "headless": "false",
-    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
-    "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO"
+    "iso_checksum": "7e3f89dbff163e259ca9b0d1f078daafd2fed513",
+    "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_SERVER_EVAL_EN-US-IRM_SSS_X64FREE_EN-US_DV5.ISO"
   }
 }


### PR DESCRIPTION
The windows 2012 build uses an ISO source that doesn't exist, this fixes that. Thanks to Derek Groh for the new URL.