### PR TITLE
Hyper-V template fixes: RAM and ISO

### DIFF
--- a/hyperv-2012r2.json
+++ b/hyperv-2012r2.json
@@ -3,7 +3,7 @@
     {
       "type": "hyperv-iso",
       "guest_additions_mode": "disable",
-      "ram_size": 2048,
+      "ram_size": 4096,
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",

--- a/hyperv-2012r2.json
+++ b/hyperv-2012r2.json
@@ -41,7 +41,7 @@
   ],
   "variables": {
     "core": "",
-    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
-    "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO"
+    "iso_checksum": "7e3f89dbff163e259ca9b0d1f078daafd2fed513",
+    "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_SERVER_EVAL_EN-US-IRM_SSS_X64FREE_EN-US_DV5.ISO"
   }
 }


### PR DESCRIPTION
Hello,

I have added two commits for the Hyper-V provisioning that you may find useful.

1. 104b9c6: Use the same ISO that the VirtualBox template uses.
2. 6222291: Increase the RAM to 4GB from 2GB.

Regards,
Robert Conde