### PR TITLE
Win2016 images - fix TLS protocol issue to allow installation of NuGet

### DIFF
--- a/cookbooks/packer-templates/recipes/install_ps_modules.rb
+++ b/cookbooks/packer-templates/recipes/install_ps_modules.rb
@@ -1,11 +1,17 @@
 powershell_script 'install Nuget package provider' do
-  code 'Install-PackageProvider -Name NuGet -Force'
+  code <<-EOH
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Install-PackageProvider -Name NuGet -Force
+  EOH
   not_if '(Get-PackageProvider -Name Nuget -ListAvailable -ErrorAction SilentlyContinue) -ne $null'
 end
 
 %w{PSWindowsUpdate xNetworking xRemoteDesktopAdmin xCertificate}.each do |ps_module|
   powershell_script "install #{ps_module} module" do
-    code "Install-Module #{ps_module} -Force"
+    code <<-EOH
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+      Install-Module #{ps_module} -Force
+    EOH
     not_if "(Get-Module #{ps_module} -list) -ne $null"
   end
 end


### PR DESCRIPTION
https://rnelson0.com/2018/05/17/powershell-in-a-post-tls1-1-world/

It looks like the Win2016 image has a powershell version whose default TLS settings are no longer sufficient for downloading stuff from Microsoft. Maybe this can also be fixed by downloading a newer installer ISO version, but I couldn't figure out where to get the most up-to-date image from.